### PR TITLE
fix: Corregir typo en las variables de mariadb

### DIFF
--- a/modulo7/files/wordpress/mariadb-deployment.yaml
+++ b/modulo7/files/wordpress/mariadb-deployment.yaml
@@ -24,7 +24,7 @@ spec:
             - containerPort: 3306
               name: db-port
           env:
-            - name: MMARIADB_USER
+            - name: MARIADB_USER
               valueFrom:
                 configMapKeyRef:
                   name: bd-datos
@@ -39,7 +39,7 @@ spec:
                 secretKeyRef:
                   name: bd-passwords
                   key: bd_password
-            - name: MMARIADB_ROOT_PASSWORD
+            - name: MARIADB_ROOT_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: bd-passwords


### PR DESCRIPTION
Algunas variables de entorno de mariadb estaban mal escritas, impidiendo
poder desplegar la aplicación correctamente.